### PR TITLE
Add a bounding box to visualisation

### DIFF
--- a/dynosam_ros/CMakeLists.txt
+++ b/dynosam_ros/CMakeLists.txt
@@ -116,6 +116,7 @@ install(DIRECTORY
 add_executable(dynosam_node src/dynosam_node.cc)
 target_link_libraries(dynosam_node
   ${PROJECT_NAME}
+  ${PCL_LIBRARIES}
 
 )
 ament_target_dependencies(dynosam_node "rclcpp" "std_msgs"

--- a/dynosam_ros/include/dynosam_ros/DisplayRos.hpp
+++ b/dynosam_ros/include/dynosam_ros/DisplayRos.hpp
@@ -78,4 +78,7 @@ protected:
     const DisplayParams params_;
 };
 
+// Axis Aligned Bounding Box (AABB)
+pcl::PointCloud<pcl::PointXYZ> findLineListPointsFromAABBMinMax(pcl::PointXYZ min_point_AABB, pcl::PointXYZ max_point_AABB);
+
 } //dyno

--- a/dynosam_ros/include/dynosam_ros/FrontendDisplayRos.hpp
+++ b/dynosam_ros/include/dynosam_ros/FrontendDisplayRos.hpp
@@ -103,6 +103,7 @@ private:
     rclcpp::Publisher<visualization_msgs::msg::MarkerArray>::SharedPtr object_motion_pub_; //! Draw object motion as arrows
 
     rclcpp::Publisher<visualization_msgs::msg::MarkerArray>::SharedPtr object_pose_pub_; //! Propogated object poses using the motion estimate
+    rclcpp::Publisher<visualization_msgs::msg::MarkerArray>::SharedPtr object_bbx_pub_; //! Draw object motion as arrows
     image_transport::Publisher tracking_image_pub_;
 
     //ground truth publishers

--- a/dynosam_ros/src/DisplayRos.cc
+++ b/dynosam_ros/src/DisplayRos.cc
@@ -240,4 +240,38 @@ void DisplayRos::publishObjectPaths(
 }
 
 
+pcl::PointCloud<pcl::PointXYZ> findLineListPointsFromAABBMinMax(pcl::PointXYZ min_point_AABB, pcl::PointXYZ max_point_AABB){
+    pcl::PointCloud<pcl::PointXYZ> line_list_points;
+
+    // bottom
+    line_list_points.push_back(pcl::PointXYZ(min_point_AABB.x, min_point_AABB.y, min_point_AABB.z));
+    line_list_points.push_back(pcl::PointXYZ(max_point_AABB.x, min_point_AABB.y, min_point_AABB.z));
+    line_list_points.push_back(pcl::PointXYZ(max_point_AABB.x, min_point_AABB.y, min_point_AABB.z));
+    line_list_points.push_back(pcl::PointXYZ(max_point_AABB.x, max_point_AABB.y, min_point_AABB.z));
+    line_list_points.push_back(pcl::PointXYZ(min_point_AABB.x, min_point_AABB.y, min_point_AABB.z));
+    line_list_points.push_back(pcl::PointXYZ(min_point_AABB.x, max_point_AABB.y, min_point_AABB.z));
+    line_list_points.push_back(pcl::PointXYZ(min_point_AABB.x, max_point_AABB.y, min_point_AABB.z));
+    line_list_points.push_back(pcl::PointXYZ(max_point_AABB.x, max_point_AABB.y, min_point_AABB.z));
+    // top
+    line_list_points.push_back(pcl::PointXYZ(min_point_AABB.x, min_point_AABB.y, max_point_AABB.z));
+    line_list_points.push_back(pcl::PointXYZ(max_point_AABB.x, min_point_AABB.y, max_point_AABB.z));
+    line_list_points.push_back(pcl::PointXYZ(max_point_AABB.x, min_point_AABB.y, max_point_AABB.z));
+    line_list_points.push_back(pcl::PointXYZ(max_point_AABB.x, max_point_AABB.y, max_point_AABB.z));
+    line_list_points.push_back(pcl::PointXYZ(min_point_AABB.x, min_point_AABB.y, max_point_AABB.z));
+    line_list_points.push_back(pcl::PointXYZ(min_point_AABB.x, max_point_AABB.y, max_point_AABB.z));
+    line_list_points.push_back(pcl::PointXYZ(min_point_AABB.x, max_point_AABB.y, max_point_AABB.z));
+    line_list_points.push_back(pcl::PointXYZ(max_point_AABB.x, max_point_AABB.y, max_point_AABB.z));
+    // vertical
+    line_list_points.push_back(pcl::PointXYZ(min_point_AABB.x, min_point_AABB.y, min_point_AABB.z));
+    line_list_points.push_back(pcl::PointXYZ(min_point_AABB.x, min_point_AABB.y, max_point_AABB.z));
+    line_list_points.push_back(pcl::PointXYZ(min_point_AABB.x, max_point_AABB.y, min_point_AABB.z));
+    line_list_points.push_back(pcl::PointXYZ(min_point_AABB.x, max_point_AABB.y, max_point_AABB.z));
+    line_list_points.push_back(pcl::PointXYZ(max_point_AABB.x, min_point_AABB.y, min_point_AABB.z));
+    line_list_points.push_back(pcl::PointXYZ(max_point_AABB.x, min_point_AABB.y, max_point_AABB.z));
+    line_list_points.push_back(pcl::PointXYZ(max_point_AABB.x, max_point_AABB.y, min_point_AABB.z));
+    line_list_points.push_back(pcl::PointXYZ(max_point_AABB.x, max_point_AABB.y, max_point_AABB.z));
+
+    return line_list_points;
+}
+
 }


### PR DESCRIPTION
Add a bounding box and an object ID to each object point cluster in the display process. 
A statistical outlier remover (PCL off-the-shelf) is used to quickly clean out some artefacts in the point cloud due to poor mask. 